### PR TITLE
Implement JWT and Redis-based token security

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,5 @@
 module github-project-status-viewer-server
 
 go 1.23
+
+require github.com/golang-jwt/jwt/v5 v5.3.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/server/pkg/auth/errors.go
+++ b/server/pkg/auth/errors.go
@@ -1,0 +1,7 @@
+package auth
+
+import "errors"
+
+var (
+	ErrInvalidAuthHeader = errors.New("authorization header must be 'Bearer <token>'")
+)

--- a/server/pkg/auth/middleware.go
+++ b/server/pkg/auth/middleware.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	"github-project-status-viewer-server/pkg/jwt"
+)
+
+func AuthenticateRequest(r *http.Request) (*jwt.Claims, error) {
+	tokenString, err := extractBearerToken(r)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, err := jwt.ValidateToken(tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+func extractBearerToken(r *http.Request) (string, error) {
+	authHeader := r.Header.Get("Authorization")
+	token, found := strings.CutPrefix(authHeader, "Bearer ")
+	if !found || token == "" {
+		return "", ErrInvalidAuthHeader
+	}
+	return token, nil
+}

--- a/server/pkg/httputil/response.go
+++ b/server/pkg/httputil/response.go
@@ -11,6 +11,20 @@ type APIError struct {
 	Description string `json:"error_description"`
 }
 
+func EnsureMethod(w http.ResponseWriter, r *http.Request, allowedMethod string) bool {
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
+	if r.Method != allowedMethod {
+		WriteError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Only "+allowedMethod+" requests are supported")
+		return false
+	}
+
+	return true
+}
+
 func JSON(w http.ResponseWriter, statusCode int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)

--- a/server/pkg/jwt/token.go
+++ b/server/pkg/jwt/token.go
@@ -1,0 +1,97 @@
+package jwt
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	TokenExpiration = 2 * time.Hour
+	TokenIssuer     = "github-project-status-viewer"
+)
+
+type Claims struct {
+	SessionID string `json:"session_id"`
+	jwt.RegisteredClaims
+}
+
+type Manager struct {
+	secret []byte
+}
+
+var (
+	defaultManager *Manager
+	initError      error
+)
+
+func init() {
+	defaultManager, initError = NewManager()
+}
+
+func GetManager() (*Manager, error) {
+	if initError != nil {
+		return nil, initError
+	}
+	return defaultManager, nil
+}
+
+func NewManager() (*Manager, error) {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		return nil, fmt.Errorf("JWT_SECRET not configured")
+	}
+	return &Manager{secret: []byte(secret)}, nil
+}
+
+func (m *Manager) GenerateToken(sessionID string) (string, error) {
+	claims := Claims{
+		SessionID: sessionID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(TokenExpiration)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    TokenIssuer,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(m.secret)
+}
+
+func (m *Manager) ValidateToken(tokenString string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return m.secret, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	claims, ok := token.Claims.(*Claims)
+	if !ok {
+		return nil, fmt.Errorf("invalid token claims type")
+	}
+
+	return claims, nil
+}
+
+func GenerateToken(sessionID string) (string, error) {
+	manager, err := GetManager()
+	if err != nil {
+		return "", err
+	}
+	return manager.GenerateToken(sessionID)
+}
+
+func ValidateToken(tokenString string) (*Claims, error) {
+	manager, err := GetManager()
+	if err != nil {
+		return nil, err
+	}
+	return manager.ValidateToken(tokenString)
+}

--- a/server/pkg/redis/client.go
+++ b/server/pkg/redis/client.go
@@ -1,0 +1,148 @@
+package redis
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	SessionKeyPrefix = "session:"
+	SessionTTL       = 30 * 24 * time.Hour
+	defaultTimeout   = 10 * time.Second
+)
+
+var ErrKeyNotFound = errors.New("key not found")
+
+type Client struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+type upstashResponse struct {
+	Result any    `json:"result"`
+	Error  string `json:"error,omitempty"`
+}
+
+var (
+	defaultClient *Client
+	initError     error
+)
+
+func init() {
+	defaultClient, initError = NewClient()
+	if initError != nil {
+		log.Printf("Warning: Redis client initialization failed: %v", initError)
+	}
+}
+
+func GetClient() (*Client, error) {
+	if initError != nil {
+		return nil, initError
+	}
+	return defaultClient, nil
+}
+
+func NewClient() (*Client, error) {
+	baseURL := os.Getenv("KV_REST_API_URL")
+	token := os.Getenv("KV_REST_API_TOKEN")
+
+	if baseURL == "" || token == "" {
+		return nil, fmt.Errorf("upstash redis configuration missing")
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		token:   token,
+		client:  &http.Client{Timeout: defaultTimeout},
+	}, nil
+}
+
+func (c *Client) Set(key string, value string, expiration time.Duration) error {
+	cmd := []any{"SET", key, value}
+	if expiration > 0 {
+		cmd = append(cmd, "EX", int(expiration.Seconds()))
+	}
+
+	_, err := c.execute(cmd)
+	return err
+}
+
+func (c *Client) Get(key string) (string, error) {
+	result, err := c.execute([]any{"GET", key})
+	if err != nil {
+		return "", err
+	}
+
+	if result == nil {
+		return "", ErrKeyNotFound
+	}
+
+	str, ok := result.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected response type")
+	}
+
+	return str, nil
+}
+
+func (c *Client) Exists(key string) (bool, error) {
+	result, err := c.execute([]any{"EXISTS", key})
+	if err != nil {
+		return false, err
+	}
+
+	count, ok := result.(float64)
+	if !ok {
+		return false, fmt.Errorf("unexpected response type")
+	}
+
+	return count > 0, nil
+}
+
+func (c *Client) execute(cmd []any) (any, error) {
+	body, err := json.Marshal(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal command: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("redis request failed with status %d (failed to read error body: %w)", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("redis request failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var response upstashResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if response.Error != "" {
+		return nil, fmt.Errorf("redis error: %s", response.Error)
+	}
+
+	return response.Result, nil
+}


### PR DESCRIPTION
GitHub OAuth Apps lack refresh tokens, forcing client-side token storage which creates security vulnerabilities. Now store GitHub tokens in Redis and issue short-lived JWTs (2h) to clients instead.

- Add JWT auth with 2-hour expiration (pkg/jwt/)
 - Add Upstash Redis client for 30-day session storage (pkg/redis/)
- Update /api/callback to store tokens in Redis and return JWT
- Add /api/verify to exchange JWT for GitHub token
- Add /api/refresh to renew JWT without re-authentication

Token theft damage now limited to 2-hour window instead of permanent access.

fix #9