### PR TITLE
Fix 401 error after 2-hour session expiry by implementing refresh token rotation

### DIFF
--- a/server/pkg/auth/middleware.go
+++ b/server/pkg/auth/middleware.go
@@ -1,31 +1,14 @@
 package auth
 
 import (
-	"net/http"
-	"strings"
-
 	"github-project-status-viewer-server/pkg/jwt"
 )
 
-func AuthenticateRequest(r *http.Request) (*jwt.Claims, error) {
-	tokenString, err := extractBearerToken(r)
-	if err != nil {
-		return nil, err
-	}
-
-	claims, err := jwt.ValidateToken(tokenString)
+func ValidateAccessToken(tokenString string) (*jwt.AccessTokenClaims, error) {
+	claims, err := jwt.ValidateAccessToken(tokenString)
 	if err != nil {
 		return nil, err
 	}
 
 	return claims, nil
-}
-
-func extractBearerToken(r *http.Request) (string, error) {
-	authHeader := r.Header.Get("Authorization")
-	token, found := strings.CutPrefix(authHeader, "Bearer ")
-	if !found || token == "" {
-		return "", ErrInvalidAuthHeader
-	}
-	return token, nil
 }

--- a/server/pkg/redis/client.go
+++ b/server/pkg/redis/client.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	SessionKeyPrefix = "session:"
-	SessionTTL       = 30 * 24 * time.Hour
-	defaultTimeout   = 10 * time.Second
+	RefreshTokenKeyPrefix = "refresh_token:"
+	RefreshTokenTTL       = 30 * 24 * time.Hour
+	SessionKeyPrefix      = "session:"
+	SessionTTL            = 30 * 24 * time.Hour
+	defaultTimeout        = 10 * time.Second
 )
 
 var ErrKeyNotFound = errors.New("key not found")
@@ -91,6 +93,11 @@ func (c *Client) Get(key string) (string, error) {
 	}
 
 	return str, nil
+}
+
+func (c *Client) Delete(key string) error {
+	_, err := c.execute([]any{"DEL", key})
+	return err
 }
 
 func (c *Client) Exists(key string) (bool, error) {


### PR DESCRIPTION
The extension failed to refresh expired JWT tokens because the /refresh endpoint required a valid JWT to generate a new JWT - creating an impossible situation after expiration.

Implemented standard OAuth refresh token pattern:
  - Separate short-lived access tokens (15min) from long-lived refresh tokens (30 days)
  - Refresh tokens can be used even when access tokens expire
  - Automatic token rotation on each refresh for security

fix #21