### PR TITLE
Fix badge display on initial page load for SPA navigation

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -27,7 +27,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/issues*"],
+      "matches": ["https://github.com/*/*"],
       "js": ["content.js"],
       "css": ["styles.css"],
       "run_at": "document_end"


### PR DESCRIPTION
  - Expand content script to load on all GitHub repository pages
  - Add debouncing (500ms) to prevent infinite MutationObserver loops
  - Implement processing flag to prevent concurrent API calls
  - Add turbo:load and pjax:end event listeners for SPA routing
  - Wait for DOMContentLoaded when page is still loading

fix #18