### PR TITLE
Reload status badges immediately after successful login

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -233,6 +233,12 @@
     init();
   }
 
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === "RELOAD_BADGES") {
+      updateIssueStatuses();
+    }
+  });
+
   document.addEventListener("turbo:load", handleSPARouting);
   document.addEventListener("pjax:end", handleSPARouting);
 })();

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -221,6 +221,14 @@
 
       showStatus(elements, "Successfully connected to GitHub!", "success");
       await updateUI(elements, true);
+
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
+      if (tab?.id) {
+        chrome.tabs.sendMessage(tab.id, { type: "RELOAD_BADGES" });
+      }
     } catch (error) {
       const message =
         error instanceof Error


### PR DESCRIPTION
Previously, users had to manually refresh the page after logging in to see project status badges. This change sends a message from the  popup to the content script upon successful authentication, triggering an immediate badge reload without requiring a page refresh.

  - Add message listener in content script for RELOAD_BADGES event
  - Send RELOAD_BADGES message to active tab after login success in popup

fix #28