### PR TITLE
Added display mode selection feature and implemented compact mode

### DIFF
--- a/extension/public/popup.html
+++ b/extension/public/popup.html
@@ -79,6 +79,22 @@
             </svg>
           </div>
         </div>
+
+        <!-- Display Mode Section -->
+        <div class="popup__setting">
+          <label class="popup__setting-label" for="displayMode"
+            >Display Mode</label
+          >
+          <select
+            id="displayMode"
+            class="popup__setting-select"
+            aria-label="Choose badge display mode"
+          >
+            <option value="full">Default</option>
+            <option value="compact">Compact</option>
+          </select>
+        </div>
+
         <button
           id="logoutBtn"
           class="popup__btn popup__btn--danger"

--- a/extension/public/styles.css
+++ b/extension/public/styles.css
@@ -1,3 +1,15 @@
+:root {
+  --badge-dark-bg: rgba(110, 118, 129, 0.15);
+  --badge-dark-color: #e6edf3;
+  --badge-dark-border: rgba(110, 118, 129, 0.3);
+  --badge-dark-dot-shadow: 0 0 0 1px rgba(13, 17, 23, 0.4);
+  --badge-dark-compact-border: rgba(13, 17, 23, 0.8);
+  --badge-dark-compact-shadow: 0 0 0 1px rgba(205, 217, 229, 0.1),
+    0 1px 2px rgba(1, 4, 9, 0.3);
+  --badge-dark-compact-hover-shadow: 0 0 0 2px rgba(13, 17, 23, 0.8),
+    0 0 0 3px rgba(205, 217, 229, 0.15), 0 2px 8px rgba(1, 4, 9, 0.4);
+}
+
 .Title-module__container--XD9YG {
   display: flex !important;
   align-items: center !important;
@@ -30,6 +42,7 @@
   border: 1px solid rgba(208, 215, 222, 0.8);
   box-sizing: border-box;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  cursor: default;
 }
 
 .project-status-badge::before {
@@ -45,30 +58,81 @@
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.8);
 }
 
+.project-status-badge--compact {
+  width: 10px;
+  height: 10px;
+  padding: 0;
+  border-radius: 50%;
+  background-color: var(--status-color);
+  border: 2px solid #ffffff;
+  box-shadow: 0 0 0 1px rgba(31, 35, 40, 0.15), 0 1px 2px rgba(31, 35, 40, 0.12);
+  cursor: help;
+  min-width: auto !important;
+  font-size: 0;
+  line-height: 0;
+  transition: transform 0.15s cubic-bezier(0.2, 0, 0.38, 0.9),
+    box-shadow 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.project-status-badge--compact::before {
+  display: none;
+}
+
+.project-status-badge--compact:hover {
+  transform: scale(1.3);
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 3px rgba(31, 35, 40, 0.2),
+    0 2px 8px rgba(31, 35, 40, 0.18);
+  z-index: 1;
+}
+
+.project-status-badge--compact:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: 2px;
+  transform: scale(1.3);
+}
+
 /* Dark mode styles - supports both system preference and GitHub's manual theme selection */
 @media (prefers-color-scheme: dark) {
   .project-status-badge {
-    background-color: rgba(110, 118, 129, 0.15);
-    color: #e6edf3;
-    border: 1px solid rgba(110, 118, 129, 0.3);
+    background-color: var(--badge-dark-bg);
+    color: var(--badge-dark-color);
+    border: 1px solid var(--badge-dark-border);
     box-shadow: none;
   }
 
   .project-status-badge::before {
     opacity: 0.85;
-    box-shadow: 0 0 0 1px rgba(13, 17, 23, 0.4);
+    box-shadow: var(--badge-dark-dot-shadow);
+  }
+
+  .project-status-badge--compact {
+    border-color: var(--badge-dark-compact-border);
+    box-shadow: var(--badge-dark-compact-shadow);
+  }
+
+  .project-status-badge--compact:hover {
+    box-shadow: var(--badge-dark-compact-hover-shadow);
   }
 }
 
 /* GitHub manual dark theme selection (data-color-mode="dark") */
 [data-color-mode="dark"] .project-status-badge {
-  background-color: rgba(110, 118, 129, 0.15);
-  color: #e6edf3;
-  border: 1px solid rgba(110, 118, 129, 0.3);
+  background-color: var(--badge-dark-bg);
+  color: var(--badge-dark-color);
+  border: 1px solid var(--badge-dark-border);
   box-shadow: none;
 }
 
 [data-color-mode="dark"] .project-status-badge::before {
   opacity: 0.85;
-  box-shadow: 0 0 0 1px rgba(13, 17, 23, 0.4);
+  box-shadow: var(--badge-dark-dot-shadow);
+}
+
+[data-color-mode="dark"] .project-status-badge--compact {
+  border-color: var(--badge-dark-compact-border);
+  box-shadow: var(--badge-dark-compact-shadow);
+}
+
+[data-color-mode="dark"] .project-status-badge--compact:hover {
+  box-shadow: var(--badge-dark-compact-hover-shadow);
 }

--- a/extension/public/styles/popup.css
+++ b/extension/public/styles/popup.css
@@ -50,7 +50,7 @@
   --btn-primary-hover: #1f2328;
   --btn-primary-active: #1c2128;
   --btn-primary-shadow: 0 1px 0 rgba(31, 35, 40, 0.1),
-                        inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
 
   --btn-danger-bg: #cf222e;
   --btn-danger-hover: #a40e26;
@@ -63,7 +63,7 @@
 
   /* Typography */
   --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
-                 Helvetica, Arial, sans-serif;
+    Helvetica, Arial, sans-serif;
   --font-size-xs: 12px;
   --font-size-sm: 13px;
   --font-size-base: 14px;
@@ -217,8 +217,7 @@ body {
 .popup__btn--primary:hover:not(:disabled) {
   background-color: var(--btn-github-hover);
   border-color: rgba(31, 35, 40, 0.25);
-  box-shadow: 0 1px 0 rgba(31, 35, 40, 0.1),
-              0 0 0 3px rgba(36, 41, 47, 0.1);
+  box-shadow: 0 1px 0 rgba(31, 35, 40, 0.1), 0 0 0 3px rgba(36, 41, 47, 0.1);
 }
 
 .popup__btn--primary:active:not(:disabled) {
@@ -309,7 +308,11 @@ body {
   width: 40px;
   height: 40px;
   border-radius: var(--radius-full);
-  background: linear-gradient(135deg, var(--color-success-emphasis) 0%, var(--color-accent-emphasis) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-success-emphasis) 0%,
+    var(--color-accent-emphasis) 100%
+  );
   display: flex;
   align-items: center;
   justify-content: center;
@@ -467,7 +470,8 @@ body {
 }
 
 @keyframes successPulse {
-  0%, 100% {
+  0%,
+  100% {
     transform: scale(1);
   }
   50% {
@@ -477,6 +481,49 @@ body {
 
 .popup__user-info--success {
   animation: successPulse 0.5s ease-out;
+}
+
+/* ============================================
+   Settings
+   ============================================ */
+
+.popup__setting {
+  margin-bottom: var(--space-4);
+  padding: var(--space-4);
+  background-color: var(--color-canvas-subtle);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-md);
+}
+
+.popup__setting-label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-default);
+  margin-bottom: var(--space-2);
+}
+
+.popup__setting-select {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-default);
+  background-color: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.popup__setting-select:hover {
+  border-color: var(--color-accent-emphasis);
+}
+
+.popup__setting-select:focus {
+  outline: none;
+  border-color: var(--color-accent-emphasis);
+  box-shadow: 0 0 0 3px var(--color-accent-bg);
 }
 
 /* ============================================


### PR DESCRIPTION
We've added Default and Compact modes, allowing users to choose how status badges are displayed in the issue list.

Key changes:
- Added a Display Mode selection dropdown to the popup.
- Compact mode: Displays only colored dots without text, and displays the full status name as a tooltip on hover.
- Implemented smooth transitions by changing only classes and attributes without regenerating DOM elements when switching modes.
- Added the data-status attribute to badges to maintain status information when switching modes.
- Added accessibility attributes (role, aria-label, tabindex) to compact mode.

fix #33