### PR TITLE
refactor: extract duplicate TypeScript type definitions

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,22 +1,6 @@
+import { IssueStatus, MessageRequest, MessageResponse } from "./shared/types";
+
 (() => {
-  type IssueStatus = {
-    color: string | null;
-    number: number;
-    status: string | null;
-  };
-
-  type MessageRequest = {
-    issueNumbers: number[];
-    owner: string;
-    repo: string;
-    type: "GET_PROJECT_STATUS";
-  };
-
-  type MessageResponse = {
-    error?: string;
-    statuses?: IssueStatus[];
-  };
-
   type VerifyResponse = {
     access_token: string;
   };

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,26 +1,7 @@
 import { getIssueNumbers } from "./issue-parser";
+import { DisplayMode, MessageRequest, MessageResponse } from "./shared/types";
 
 (() => {
-  type DisplayMode = "compact" | "full";
-
-  type IssueStatus = {
-    color: string | null;
-    number: number;
-    status: string | null;
-  };
-
-  type MessageRequest = {
-    issueNumbers: number[];
-    owner: string;
-    repo: string;
-    type: "GET_PROJECT_STATUS";
-  };
-
-  type MessageResponse = {
-    error?: string;
-    statuses?: IssueStatus[];
-  };
-
   const BADGE_CLASS = "project-status-badge";
   const BADGE_COMPACT_CLASS = "project-status-badge--compact";
   const DEBOUNCE_DELAY_MS = 500;

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -1,12 +1,10 @@
+import { DisplayMode, StatusType } from "./shared/types";
+
 (() => {
   type CallbackResponse = {
     access_token: string;
     refresh_token: string;
   };
-
-  type DisplayMode = "compact" | "full";
-
-  type StatusType = "error" | "info" | "success";
 
   type UIElements = {
     displayModeSelect: HTMLSelectElement;

--- a/extension/src/shared/types.ts
+++ b/extension/src/shared/types.ts
@@ -1,0 +1,21 @@
+export type DisplayMode = "compact" | "full";
+
+export type StatusType = "error" | "info" | "success";
+
+export type IssueStatus = {
+  color: string | null;
+  number: number;
+  status: string | null;
+};
+
+export type MessageRequest = {
+  issueNumbers: number[];
+  owner: string;
+  repo: string;
+  type: "GET_PROJECT_STATUS";
+};
+
+export type MessageResponse = {
+  error?: string;
+  statuses?: IssueStatus[];
+};


### PR DESCRIPTION
Moved 40+ duplicate type definition lines from 3 files to shared/types.ts
- Removed duplicate types from background.ts, content.ts, popup.ts
- Centralized IssueStatus, MessageRequest, MessageResponse, DisplayMode, StatusType

fix #48