### PR TITLE
refactor: replace init() pattern with sync.OnceValues for predictable initialization

### DIFF
--- a/server/pkg/jwt/token.go
+++ b/server/pkg/jwt/token.go
@@ -2,7 +2,9 @@ package jwt
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -29,20 +31,16 @@ type Manager struct {
 	secret []byte
 }
 
-var (
-	defaultManager *Manager
-	initError      error
-)
-
-func init() {
-	defaultManager, initError = NewManager()
-}
+var getManagerFunc = sync.OnceValues(func() (*Manager, error) {
+	manager, err := NewManager()
+	if err != nil {
+		slog.Warn("JWT Manager initialization failed", "error", err)
+	}
+	return manager, err
+})
 
 func GetManager() (*Manager, error) {
-	if initError != nil {
-		return nil, initError
-	}
-	return defaultManager, nil
+	return getManagerFunc()
 }
 
 func NewManager() (*Manager, error) {


### PR DESCRIPTION
- Migrated from Go init() pattern to sync.OnceValues for better initialization predictability
- Added concurrency safety tests across redis, jwt, oauth packages (100 goroutines with race detector)
- Reduced code lines per package (15 → 6 lines) with improved type safety

fix #50