### PR TITLE
refactor: extract duplicate crypto random generation logic to centralized utilities

### DIFF
--- a/server/api/callback/index.go
+++ b/server/api/callback/index.go
@@ -1,40 +1,18 @@
 package handler
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"net/http"
 
+	"github-project-status-viewer-server/pkg/crypto"
 	"github-project-status-viewer-server/pkg/httputil"
 	"github-project-status-viewer-server/pkg/jwt"
 	"github-project-status-viewer-server/pkg/oauth"
 	"github-project-status-viewer-server/pkg/redis"
 )
 
-const (
-	refreshTokenIDBytes = 32
-	sessionIDBytes      = 32
-)
-
 type CallbackResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
-}
-
-func generateRefreshTokenID() (string, error) {
-	bytes := make([]byte, refreshTokenIDBytes)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
-}
-
-func generateSessionID() (string, error) {
-	bytes := make([]byte, sessionIDBytes)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +58,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sessionID, err := generateSessionID()
+	sessionID, err := crypto.GenerateSessionID()
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "server_error", "Failed to generate session ID")
 		return
@@ -91,7 +69,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	refreshTokenID, err := generateRefreshTokenID()
+	refreshTokenID, err := crypto.GenerateRefreshTokenID()
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "server_error", "Failed to generate refresh token ID")
 		return

--- a/server/api/refresh/index.go
+++ b/server/api/refresh/index.go
@@ -1,29 +1,18 @@
 package handler
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"net/http"
 
+	"github-project-status-viewer-server/pkg/crypto"
 	"github-project-status-viewer-server/pkg/httputil"
 	"github-project-status-viewer-server/pkg/jwt"
 	"github-project-status-viewer-server/pkg/oauth"
 	"github-project-status-viewer-server/pkg/redis"
 )
 
-const refreshTokenIDBytes = 32
-
 type RefreshResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
-}
-
-func generateRefreshTokenID() (string, error) {
-	bytes := make([]byte, refreshTokenIDBytes)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +72,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newRefreshTokenID, err := generateRefreshTokenID()
+	newRefreshTokenID, err := crypto.GenerateRefreshTokenID()
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "server_error", "Failed to generate refresh token ID")
 		return

--- a/server/pkg/crypto/random.go
+++ b/server/pkg/crypto/random.go
@@ -1,0 +1,27 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+const (
+	RefreshTokenIDBytes = 32
+	SessionIDBytes      = 32
+)
+
+func generateRandomHex(byteLength int) (string, error) {
+	bytes := make([]byte, byteLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func GenerateRefreshTokenID() (string, error) {
+	return generateRandomHex(RefreshTokenIDBytes)
+}
+
+func GenerateSessionID() (string, error) {
+	return generateRandomHex(SessionIDBytes)
+}

--- a/server/pkg/crypto/random_test.go
+++ b/server/pkg/crypto/random_test.go
@@ -1,0 +1,130 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestGenerateRandomID(t *testing.T) {
+	testCases := []struct {
+		name          string
+		generateFunc  func() (string, error)
+		expectedBytes int
+	}{
+		{
+			name:          "GenerateRefreshTokenID",
+			generateFunc:  GenerateRefreshTokenID,
+			expectedBytes: RefreshTokenIDBytes,
+		},
+		{
+			name:          "GenerateSessionID",
+			generateFunc:  GenerateSessionID,
+			expectedBytes: SessionIDBytes,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("should generate valid hex string", func(t *testing.T) {
+				t.Parallel()
+				id, err := tc.generateFunc()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				expectedLength := tc.expectedBytes * 2
+				if len(id) != expectedLength {
+					t.Errorf("expected length %d, got %d", expectedLength, len(id))
+				}
+
+				if _, err := hex.DecodeString(id); err != nil {
+					t.Errorf("not a valid hex string: %v", err)
+				}
+			})
+
+			t.Run("should generate unique IDs", func(t *testing.T) {
+				t.Parallel()
+				ids := make(map[string]bool)
+				iterations := 1000
+
+				for i := 0; i < iterations; i++ {
+					id, err := tc.generateFunc()
+					if err != nil {
+						t.Fatalf("unexpected error at iteration %d: %v", i, err)
+					}
+
+					if ids[id] {
+						t.Errorf("duplicate ID generated: %s", id)
+					}
+					ids[id] = true
+				}
+
+				if len(ids) != iterations {
+					t.Errorf("expected %d unique IDs, got %d", iterations, len(ids))
+				}
+			})
+
+			t.Run("should only contain lowercase hex characters", func(t *testing.T) {
+				t.Parallel()
+				id, err := tc.generateFunc()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				for _, char := range id {
+					if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
+						t.Errorf("invalid character %c in ID %s", char, id)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestIDDifference(t *testing.T) {
+	t.Run("refresh token ID and session ID should be different", func(t *testing.T) {
+		refreshID, err := GenerateRefreshTokenID()
+		if err != nil {
+			t.Fatalf("failed to generate refresh token ID: %v", err)
+		}
+
+		sessionID, err := GenerateSessionID()
+		if err != nil {
+			t.Fatalf("failed to generate session ID: %v", err)
+		}
+
+		if refreshID == sessionID {
+			t.Errorf("refresh token ID and session ID should not be the same")
+		}
+	})
+}
+
+func BenchmarkGenerateRandomID(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		generateFunc func() (string, error)
+	}{
+		{
+			name:         "GenerateRefreshTokenID",
+			generateFunc: GenerateRefreshTokenID,
+		},
+		{
+			name:         "GenerateSessionID",
+			generateFunc: GenerateSessionID,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := bm.generateFunc()
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extracted generateRefreshTokenID() and generateSessionID() functions duplicated
across callback and refresh API handlers into pkg/crypto package

- Created server/pkg/crypto/random.go (GenerateRefreshTokenID, GenerateSessionID)
- Added uniqueness and format validation tests (1000 iterations)
- Removed 38 lines of duplicate code from two API handlers

fix #51