### PR TITLE
refactor: extract badge rendering logic to standalone service

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -16,16 +16,24 @@ import { MessageRequest, MessageResponse } from "./shared/types";
         STORAGE_KEYS.REFRESH_TOKEN,
       ]);
 
-      if (!result[STORAGE_KEYS.ACCESS_TOKEN] || !result[STORAGE_KEYS.REFRESH_TOKEN]) {
+      const accessToken = result[STORAGE_KEYS.ACCESS_TOKEN];
+      const refreshToken = result[STORAGE_KEYS.REFRESH_TOKEN];
+
+      if (
+        typeof accessToken !== "string" ||
+        !accessToken ||
+        typeof refreshToken !== "string" ||
+        !refreshToken
+      ) {
         sendResponse({ error: ERROR_MESSAGES.AUTH_REQUIRED });
         return true;
       }
 
       const statuses = await fetchProjectStatus({
-        accessToken: result[STORAGE_KEYS.ACCESS_TOKEN],
+        accessToken,
         issueNumbers: request.issueNumbers,
         owner: request.owner,
-        refreshToken: result[STORAGE_KEYS.REFRESH_TOKEN],
+        refreshToken,
         repo: request.repo,
       });
 

--- a/extension/src/constants/ui.ts
+++ b/extension/src/constants/ui.ts
@@ -23,6 +23,7 @@ export const ELEMENT_IDS = {
 
 export const SELECTORS = {
   ISSUE_LINK: '[data-testid="issue-pr-title-link"]',
+  ISSUE_TITLE_CONTAINER: "h3",
 } as const;
 
 export const STATUS_ICONS = {

--- a/extension/src/services/badge-renderer.service.spec.ts
+++ b/extension/src/services/badge-renderer.service.spec.ts
@@ -1,0 +1,321 @@
+import { CSS_CLASSES, SELECTORS, UI_DEFAULTS } from "../constants/ui";
+import {
+  applyUniformWidth,
+  calculateMaxBadgeWidth,
+  createBadge,
+  insertBadge,
+  refreshAllBadgeDisplays,
+  updateBadgeDisplay,
+} from "./badge-renderer.service";
+
+const createIssueHTML = (
+  issueNumber: number,
+  options?: { withBadge?: boolean; withoutH3?: boolean }
+): string => {
+  const linkAttribute = SELECTORS.ISSUE_LINK.replace(/[[\]]/g, "");
+  const issueLink = `<a ${linkAttribute} href="/owner/repo/issues/${issueNumber}">Issue #${issueNumber}</a>`;
+
+  if (options?.withoutH3) {
+    return `<div>${issueLink}</div>`;
+  }
+
+  const h3Element = `<h3>${issueLink}</h3>`;
+  const badge = options?.withBadge ? `<span class="${CSS_CLASSES.BADGE}">Existing</span>` : "";
+
+  return `<div>${badge}${h3Element}</div>`;
+};
+
+describe("badge-renderer.service", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("calculateMaxBadgeWidth", () => {
+    it("should return 0 when no badges exist", () => {
+      const result = calculateMaxBadgeWidth();
+
+      expect(result).toBe(0);
+    });
+
+    it("should calculate maximum width among badges", () => {
+      document.body.innerHTML = `
+        <div>
+          <span class="${CSS_CLASSES.BADGE}" style="width: 50px; display: inline-block;">Status 1</span>
+          <span class="${CSS_CLASSES.BADGE}" style="width: 80px; display: inline-block;">Status 2</span>
+          <span class="${CSS_CLASSES.BADGE}" style="width: 30px; display: inline-block;">Status 3</span>
+        </div>
+      `;
+
+      const result = calculateMaxBadgeWidth();
+
+      expect(result).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("applyUniformWidth", () => {
+    it("should not apply width when maxWidth is 0", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE}">Badge</span>
+      `;
+
+      applyUniformWidth({ maxWidth: 0 });
+
+      const badge = document.querySelector(`.${CSS_CLASSES.BADGE}`) as HTMLElement;
+      expect(badge.style.minWidth).toBe("");
+    });
+
+    it("should apply minWidth to all full-mode badges", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE}">Badge 1</span>
+        <span class="${CSS_CLASSES.BADGE}">Badge 2</span>
+      `;
+
+      applyUniformWidth({ maxWidth: 100 });
+
+      const badges = document.querySelectorAll(`.${CSS_CLASSES.BADGE}`);
+      badges.forEach((badge) => {
+        expect((badge as HTMLElement).style.minWidth).toBe("100px");
+      });
+    });
+
+    it("should not apply width to compact badges", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE} ${CSS_CLASSES.BADGE_COMPACT}">Compact</span>
+        <span class="${CSS_CLASSES.BADGE}">Full</span>
+      `;
+
+      applyUniformWidth({ maxWidth: 100 });
+
+      const compactBadge = document.querySelector(`.${CSS_CLASSES.BADGE_COMPACT}`) as HTMLElement;
+      const fullBadge = document.querySelector(
+        `.${CSS_CLASSES.BADGE}:not(.${CSS_CLASSES.BADGE_COMPACT})`
+      ) as HTMLElement;
+
+      expect(compactBadge.style.minWidth).toBe("");
+      expect(fullBadge.style.minWidth).toBe("100px");
+    });
+  });
+
+  describe("createBadge", () => {
+    it("should create badge with full display mode", () => {
+      const badge = createBadge({ color: "#ff5733", displayMode: "full", status: "In Progress" });
+
+      expect(badge.className).toBe(CSS_CLASSES.BADGE);
+      expect(badge.getAttribute("data-status")).toBe("In Progress");
+      expect(badge.style.getPropertyValue("--status-color")).toBe("#ff5733");
+      expect(badge.textContent).toBe("In Progress");
+      expect(badge.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(false);
+    });
+
+    it("should create badge with compact display mode", () => {
+      const badge = createBadge({ color: "#00ff00", displayMode: "compact", status: "Done" });
+
+      expect(badge.className).toContain(CSS_CLASSES.BADGE_COMPACT);
+      expect(badge.textContent).toBe("");
+      expect(badge.title).toBe("Done");
+      expect(badge.getAttribute("aria-label")).toBe("Status: Done");
+      expect(badge.getAttribute("role")).toBe("img");
+      expect(badge.tabIndex).toBe(0);
+    });
+
+    it("should use default color when color is null", () => {
+      const badge = createBadge({ color: null, displayMode: "full", status: "Todo" });
+
+      expect(badge.style.getPropertyValue("--status-color")).toBe(UI_DEFAULTS.BADGE_COLOR);
+    });
+  });
+
+  describe("updateBadgeDisplay", () => {
+    it("should update badge to full mode", () => {
+      const badge = document.createElement("span");
+      badge.className = `${CSS_CLASSES.BADGE} ${CSS_CLASSES.BADGE_COMPACT}`;
+      badge.textContent = "";
+      badge.title = "Old Status";
+      badge.setAttribute("role", "img");
+      badge.setAttribute("aria-label", "Status: Old");
+      badge.tabIndex = 0;
+
+      updateBadgeDisplay({ badge, displayMode: "full", status: "New Status" });
+
+      expect(badge.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(false);
+      expect(badge.textContent).toBe("New Status");
+      expect(badge.title).toBe("");
+      expect(badge.getAttribute("role")).toBeNull();
+      expect(badge.getAttribute("aria-label")).toBeNull();
+      expect(badge.tabIndex).toBe(-1);
+    });
+
+    it("should update badge to compact mode", () => {
+      const badge = document.createElement("span");
+      badge.className = CSS_CLASSES.BADGE;
+      badge.textContent = "Old Status";
+      badge.style.minWidth = "100px";
+
+      updateBadgeDisplay({ badge, displayMode: "compact", status: "New Status" });
+
+      expect(badge.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(true);
+      expect(badge.textContent).toBe("");
+      expect(badge.title).toBe("New Status");
+      expect(badge.getAttribute("role")).toBe("img");
+      expect(badge.getAttribute("aria-label")).toBe("Status: New Status");
+      expect(badge.tabIndex).toBe(0);
+      expect(badge.style.minWidth).toBe("");
+    });
+  });
+
+  describe("insertBadge", () => {
+    it("should insert badge for matching issue number", () => {
+      document.body.innerHTML = createIssueHTML(123);
+
+      const result = insertBadge({
+        color: "#ff5733",
+        displayMode: "full",
+        issueNumber: 123,
+        status: "In Progress",
+      });
+
+      expect(result).toBe(true);
+      const badge = document.querySelector(`.${CSS_CLASSES.BADGE}`);
+      expect(badge).not.toBeNull();
+      expect(badge?.getAttribute("data-status")).toBe("In Progress");
+    });
+
+    it("should not insert badge if already exists", () => {
+      document.body.innerHTML = createIssueHTML(123, { withBadge: true });
+
+      const result = insertBadge({
+        color: "#ff5733",
+        displayMode: "full",
+        issueNumber: 123,
+        status: "New Status",
+      });
+
+      expect(result).toBe(false);
+      const badges = document.querySelectorAll(`.${CSS_CLASSES.BADGE}`);
+      expect(badges.length).toBe(1);
+    });
+
+    it("should return false for non-matching issue number", () => {
+      document.body.innerHTML = createIssueHTML(456);
+
+      const result = insertBadge({
+        color: "#ff5733",
+        displayMode: "full",
+        issueNumber: 123,
+        status: "In Progress",
+      });
+
+      expect(result).toBe(false);
+      const badge = document.querySelector(`.${CSS_CLASSES.BADGE}`);
+      expect(badge).toBeNull();
+    });
+
+    it("should handle missing h3 element", () => {
+      document.body.innerHTML = createIssueHTML(123, { withoutH3: true });
+
+      const result = insertBadge({
+        color: "#ff5733",
+        displayMode: "full",
+        issueNumber: 123,
+        status: "In Progress",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("refreshAllBadgeDisplays", () => {
+    it("should refresh all badges to full mode", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE} ${CSS_CLASSES.BADGE_COMPACT}" data-status="Status 1"></span>
+        <span class="${CSS_CLASSES.BADGE} ${CSS_CLASSES.BADGE_COMPACT}" data-status="Status 2"></span>
+      `;
+
+      refreshAllBadgeDisplays("full");
+
+      const badges = document.querySelectorAll(`.${CSS_CLASSES.BADGE}`);
+      badges.forEach((badge) => {
+        expect(badge.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(false);
+        expect(badge.textContent).toBeTruthy();
+      });
+    });
+
+    it("should refresh all badges to compact mode", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE}" data-status="Status 1">Status 1</span>
+        <span class="${CSS_CLASSES.BADGE}" data-status="Status 2">Status 2</span>
+      `;
+
+      refreshAllBadgeDisplays("compact");
+
+      const badges = document.querySelectorAll(`.${CSS_CLASSES.BADGE}`);
+      badges.forEach((badge) => {
+        expect(badge.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(true);
+        expect(badge.textContent).toBe("");
+      });
+    });
+
+    it("should skip badges without data-status attribute", () => {
+      document.body.innerHTML = `
+        <span class="${CSS_CLASSES.BADGE}" data-status="Status 1">Status 1</span>
+        <span class="${CSS_CLASSES.BADGE}">No Status</span>
+      `;
+
+      refreshAllBadgeDisplays("compact");
+
+      const badgeWithStatus = document.querySelector('[data-status="Status 1"]');
+      const badgeWithoutStatus = document.querySelectorAll(`.${CSS_CLASSES.BADGE}`)[1];
+
+      expect(badgeWithStatus?.classList.contains(CSS_CLASSES.BADGE_COMPACT)).toBe(true);
+      expect(badgeWithoutStatus.textContent).toBe("No Status");
+    });
+  });
+
+  describe("various status values", () => {
+    const testCases = [
+      { color: "#cccccc", status: "Todo" },
+      { color: "#ff5733", status: "In Progress" },
+      { color: "#00ff00", status: "Done" },
+      { color: "#ff0000", status: "Blocked" },
+      { color: "#0088ff", status: "Review" },
+    ];
+
+    testCases.forEach(({ color, status }) => {
+      it(`should correctly render ${status} badge in full mode`, () => {
+        const badge = createBadge({ color, displayMode: "full", status });
+
+        expect(badge.textContent).toBe(status);
+        expect(badge.style.getPropertyValue("--status-color")).toBe(color);
+        expect(badge.getAttribute("data-status")).toBe(status);
+      });
+
+      it(`should correctly render ${status} badge in compact mode`, () => {
+        const badge = createBadge({ color, displayMode: "compact", status });
+
+        expect(badge.textContent).toBe("");
+        expect(badge.title).toBe(status);
+        expect(badge.getAttribute("aria-label")).toBe(`Status: ${status}`);
+        expect(badge.style.getPropertyValue("--status-color")).toBe(color);
+      });
+    });
+
+    it("should handle special characters in status", () => {
+      const badge = createBadge({
+        color: "#ffaa00",
+        displayMode: "full",
+        status: "⚠️ Needs Review",
+      });
+
+      expect(badge.textContent).toBe("⚠️ Needs Review");
+      expect(badge.getAttribute("data-status")).toBe("⚠️ Needs Review");
+    });
+
+    it("should handle long status text", () => {
+      const longStatus = "This is a very long status text that might need to be truncated";
+      const badge = createBadge({ color: "#000000", displayMode: "full", status: longStatus });
+
+      expect(badge.textContent).toBe(longStatus);
+      expect(badge.getAttribute("data-status")).toBe(longStatus);
+    });
+  });
+});

--- a/extension/src/services/badge-renderer.service.ts
+++ b/extension/src/services/badge-renderer.service.ts
@@ -1,0 +1,117 @@
+import { CSS_CLASSES, SELECTORS, UI_DEFAULTS } from "../constants/ui";
+import { DisplayMode } from "../shared/types";
+
+type ApplyUniformWidthParams = {
+  maxWidth: number;
+};
+
+type CreateBadgeParams = {
+  color: string | null;
+  displayMode: DisplayMode;
+  status: string;
+};
+
+type InsertBadgeParams = {
+  color: string | null;
+  displayMode: DisplayMode;
+  issueNumber: number;
+  status: string;
+};
+
+type UpdateBadgeDisplayParams = {
+  badge: HTMLElement;
+  displayMode: DisplayMode;
+  status: string;
+};
+
+export const applyUniformWidth = ({ maxWidth }: ApplyUniformWidthParams): void => {
+  if (maxWidth === 0) return;
+
+  const badges = document.querySelectorAll<HTMLElement>(
+    `.${CSS_CLASSES.BADGE}:not(.${CSS_CLASSES.BADGE_COMPACT})`
+  );
+  badges.forEach((badge) => {
+    badge.style.minWidth = `${maxWidth}px`;
+  });
+};
+
+export const calculateMaxBadgeWidth = (): number => {
+  const badges = document.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.BADGE}`);
+  return Array.from(badges).reduce(
+    (maxWidth, badge) => Math.max(maxWidth, badge.getBoundingClientRect().width),
+    0
+  );
+};
+
+export const createBadge = ({ color, displayMode, status }: CreateBadgeParams): HTMLElement => {
+  const badge = document.createElement("span");
+  badge.className = CSS_CLASSES.BADGE;
+  badge.setAttribute("data-status", status);
+  badge.style.setProperty("--status-color", color ?? UI_DEFAULTS.BADGE_COLOR);
+
+  updateBadgeDisplay({ badge, displayMode, status });
+
+  return badge;
+};
+
+export const insertBadge = ({
+  color,
+  displayMode,
+  issueNumber,
+  status,
+}: InsertBadgeParams): boolean => {
+  const issueLinks = document.querySelectorAll(SELECTORS.ISSUE_LINK);
+
+  for (const link of issueLinks) {
+    const href = link.getAttribute("href");
+    if (!href?.includes(`/issues/${issueNumber}`)) continue;
+
+    const h3Element = link.closest(SELECTORS.ISSUE_TITLE_CONTAINER);
+    if (!h3Element) continue;
+
+    const container = h3Element.parentElement;
+    if (!container) continue;
+
+    if (container.querySelector(`.${CSS_CLASSES.BADGE}`)) return false;
+
+    const badge = createBadge({ color, displayMode, status });
+    container.insertBefore(badge, h3Element);
+    return true;
+  }
+
+  return false;
+};
+
+export const refreshAllBadgeDisplays = (displayMode: DisplayMode): void => {
+  const badges = document.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.BADGE}`);
+
+  badges.forEach((badge) => {
+    const statusText = badge.getAttribute("data-status");
+    if (statusText) {
+      updateBadgeDisplay({ badge, displayMode, status: statusText });
+    }
+  });
+};
+
+export const updateBadgeDisplay = ({
+  badge,
+  displayMode,
+  status,
+}: UpdateBadgeDisplayParams): void => {
+  if (displayMode === "compact") {
+    badge.classList.add(CSS_CLASSES.BADGE_COMPACT);
+    badge.textContent = "";
+    badge.title = status;
+    badge.setAttribute("role", "img");
+    badge.setAttribute("aria-label", `Status: ${status}`);
+    badge.tabIndex = 0;
+    badge.style.minWidth = "";
+  } else {
+    badge.classList.remove(CSS_CLASSES.BADGE_COMPACT);
+    badge.textContent = status;
+    badge.title = "";
+    badge.removeAttribute("role");
+    badge.removeAttribute("aria-label");
+    badge.tabIndex = -1;
+  }
+};

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -2,14 +2,15 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "chrome"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "src/**/*.spec.ts", "src/**/*.test.ts", "test-utils/**/*"]
+  "exclude": ["node_modules", "test-utils/**/*"]
 }


### PR DESCRIPTION
Separated DOM manipulation code from content.ts into badge-renderer.service for testable architecture

- Extracted badge creation, update, insertion, and width calculation functions to service layer
- Added 29 test cases covering DOM manipulation logic (various status values and edge cases)
- Reduced content.ts code by 27% (256 lines → 186 lines)
- Improved type safety for chrome.storage in background.ts

fix #53